### PR TITLE
Optimize initial ssh connect time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
  "dns-lookup",
  "graphql_client",
  "indicatif",
+ "ipnet",
+ "network-interface",
  "open",
  "rand",
  "reqwest",
@@ -611,6 +613,17 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "network-interface"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8d155b18a454a0551e9c691639f5d7530cfdeafe8a67588b80a53ebdf06248"
+dependencies = [
+ "libc",
+ "thiserror",
+ "windows",
 ]
 
 [[package]]
@@ -1394,16 +1407,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -1413,10 +1439,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1425,16 +1463,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ serde_json = "1.0"
 graphql_client = { version = "0.11" }
 dirs = "4.0.0"
 dns-lookup = "1.0.8"
+network-interface = "0.1.1"
+ipnet = "2.5.0"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,19 @@
+use std::net::Ipv6Addr;
+
+use anyhow::{Context, Result};
+use ipnet::Ipv6Net;
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+
+pub fn get_tailscale_ipv6() -> Result<Ipv6Addr> {
+    let network_interfaces = NetworkInterface::show()?;
+    let mask: Ipv6Net = "fd7a:115c:a1e0:ab12::/64".parse()?;
+    let filtered = network_interfaces
+        .iter()
+        .filter_map(|i| match i.addr {
+            Some(Addr::V6(v6)) => Some(v6.ip),
+            _ => None,
+        })
+        .filter(|i| mask.contains(i))
+        .next();
+    filtered.context("No Tailscale interface found")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod client;
 mod commands;
 mod config;
 mod gql;
+mod interface;
 
 /// Ephemeral virtual machines, leveraging Fly.io
 #[derive(Parser)]

--- a/stamp/Dockerfile.full
+++ b/stamp/Dockerfile.full
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu
 RUN apt-get update
 RUN yes | unminimize
 RUN apt-get install -y curl sudo htop tmux nano ncdu clang wget unzip zip git git-lfs build-essential jq less man-db ripgrep ninja-build cmake neofetch
@@ -23,4 +23,4 @@ RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
     && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
     && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
 
-ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY && dockerd" ]
+ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY; sleep 1 && curl $TAILSCALE_ADDR && dockerd" ]

--- a/stamp/Dockerfile.minimal
+++ b/stamp/Dockerfile.minimal
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu
 RUN apt-get update && apt-get install -y curl sudo htop tmux nano ncdu wget unzip zip git less man-db
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh
@@ -21,4 +21,4 @@ RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
     && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
     && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
 
-ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY && tail -f /dev/null" ]
+ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY; sleep 1 && curl $TAILSCALE_ADDR & tail -f /dev/null" ]

--- a/stamp/Dockerfile.minimal-docker
+++ b/stamp/Dockerfile.minimal-docker
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu
 RUN apt-get update && apt-get install -y curl sudo htop tmux nano ncdu wget unzip zip git less man-db
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh
@@ -21,4 +21,4 @@ RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
     && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
     && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
 
-ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY && dockerd" ]
+ENTRYPOINT [ "/bin/bash", "-c", "sudo tailscaled & tailscale up --ssh --auth-key $TAILSCALE_AUTHKEY; sleep 1 && curl $TAILSCALE_ADDR && dockerd" ]


### PR DESCRIPTION
Instead of busy polling the MagicDNS hostname of the launched machine, we await a connection initiated by the machine once `tailscale` has finished initializing.
This more than halves the time from command run to ssh session start.

Replaces the base image for `fade-stamp` with `ubuntu:latest` rather than `ubuntu:rolling`