### PR TITLE
Migrate to Fly's REST API instead of GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Create and destroy temporary virtual machines in seconds.
 
 ## Dependencies
 - [`tailscale`](https://tailscale.com/download)
+- [`flyctl`](https://fly.io/docs/getting-started/installing-flyctl)
 - `ssh`
 
 ## Install

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,0 +1,102 @@
+use std::{process::Stdio, time::Duration};
+
+use anyhow::Context;
+use indicatif::ProgressBar;
+use tokio::{net::TcpStream, process::Command};
+
+use crate::{
+    client::{delete_rest, get_rest, post_graphql, AuthorizedClient},
+    config::Configs,
+    gql::queries::{get_organization_meta, GetOrganizationMeta},
+    rest::list_machines::ListMachines,
+};
+
+use super::*;
+
+pub async fn command() -> Result<()> {
+    let config = Configs::new().await?;
+    let client = AuthorizedClient::new(&config)?;
+
+    let res = post_graphql::<GetOrganizationMeta, _>(
+        &client,
+        "https://api.fly.io/graphql",
+        get_organization_meta::Variables {
+            id: None,
+            name: None,
+            slug: Some(config.root_config.fly_organization.clone()),
+        },
+    )
+    .await?;
+    let data = res.data.context("Failed to retrieve response body")?;
+    let organization = data
+        .organization
+        .context("Failed to retrieve organization")?;
+
+    let _proxy_command = if tokio::time::timeout(
+        Duration::from_millis(200),
+        TcpStream::connect(FLY_API_HOSTNAME),
+    )
+    .await
+    .ok()
+    .transpose()
+    .ok()
+    .flatten()
+    .is_none()
+    {
+        let spinner = ProgressBar::new_spinner().with_message("Starting fly api proxy");
+        spinner.enable_steady_tick(50);
+
+        let mut proxy_command = Command::new("flyctl")
+            .arg("machines")
+            .arg("api-proxy")
+            .arg("-o")
+            .stdout(Stdio::piped())
+            .arg(organization.slug)
+            .kill_on_drop(true)
+            .spawn()?;
+        let stdout = proxy_command
+            .stdout
+            .take()
+            .context("Failed to take stdout")?;
+
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.contains("Proxying local port") {
+                    break;
+                }
+            }
+        })
+        .await?;
+        spinner.finish_with_message("Started fly api proxy");
+        Some(proxy_command)
+    } else {
+        None
+    };
+
+    let machines = get_rest::<ListMachines, _>(
+        &client,
+        format!(
+            "http://{FLY_API_HOSTNAME}/v1/apps/{}/machines",
+            config.fly_app_name(),
+        ),
+    )
+    .await?;
+
+    let stopped = machines.iter().filter(|m| m.state == "stopped");
+
+    for machine in stopped {
+        delete_rest::<_>(
+            &client,
+            format!(
+                "http://{FLY_API_HOSTNAME}/v1/apps/{}/machines/{}",
+                config.fly_app_name(),
+                machine.id,
+            ),
+        )
+        .await?;
+        println!("Deleted machine {}", machine.id);
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,6 @@
+pub mod cleanup;
 pub mod new;
 pub mod setup;
 
+pub(super) static FLY_API_HOSTNAME: &str = "localhost:4280";
 pub(super) use anyhow::Result;

--- a/src/gql/machine_config.rs
+++ b/src/gql/machine_config.rs
@@ -9,7 +9,7 @@ pub struct MachineConfig {
     pub image: String,
     pub metadata: Option<HashMap<String, String>>,
     pub restart: Option<Restart>,
-    pub guest: Guest,
+    pub guest: Option<Guest>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use clap::{clap_derive::ArgEnum, Parser, Subcommand};
-use commands::{new, setup};
+use commands::{cleanup, new, setup};
 
 mod client;
 mod commands;
 mod config;
 mod gql;
 mod interface;
+mod rest;
 
 /// Ephemeral virtual machines, leveraging Fly.io
 #[derive(Parser)]
@@ -41,6 +42,9 @@ enum Commands {
         region: Option<String>,
     },
 
+    /// Clean up stopped machines
+    Cleanup,
+
     /// Configure initial Fly settings
     Setup,
 }
@@ -55,6 +59,7 @@ async fn main() -> Result<()> {
             memory,
             region,
         } => new::command(kind, memory, region).await?,
+        Commands::Cleanup => cleanup::command().await?,
         Commands::Setup => setup::command().await?,
     }
 

--- a/src/rest/launch_machine.rs
+++ b/src/rest/launch_machine.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gql::machine_config::MachineConfig;
+
+use super::RestQuery;
+
+pub struct LaunchMachine;
+
+impl RestQuery for LaunchMachine {
+    type RequestData = LaunchMachineRequest;
+    type ResponseData = LaunchMachineResponse;
+}
+
+#[derive(Debug, Serialize)]
+pub struct LaunchMachineRequest {
+    pub name: Option<String>,
+    pub region: Option<String>,
+    pub config: MachineConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LaunchMachineResponse {
+    pub id: String,
+    pub name: String,
+    pub state: String,
+    pub region: String,
+    pub instance_id: String,
+    pub private_ip: String,
+    pub config: MachineConfig,
+    pub image_ref: ImageRef,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageRef {
+    pub registry: String,
+    pub repository: String,
+    pub tag: String,
+    pub digest: String,
+    pub labels: HashMap<String, String>,
+}

--- a/src/rest/list_machines.rs
+++ b/src/rest/list_machines.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gql::machine_config::MachineConfig;
+
+pub type ListMachines = Vec<Machine>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Machine {
+    pub id: String,
+    pub name: String,
+    pub state: String,
+    pub region: String,
+    pub instance_id: String,
+    pub private_ip: String,
+    pub config: MachineConfig,
+    pub image_ref: ImageRef,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageRef {
+    pub registry: String,
+    pub repository: String,
+    pub tag: String,
+    pub digest: String,
+    pub labels: HashMap<String, String>,
+}

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -1,0 +1,8 @@
+pub trait RestQuery {
+    type RequestData: serde::ser::Serialize;
+    type ResponseData: for<'de> serde::Deserialize<'de>;
+}
+
+pub mod launch_machine;
+pub mod list_machines;
+pub mod stop_machine;

--- a/src/rest/stop_machine.rs
+++ b/src/rest/stop_machine.rs
@@ -1,0 +1,14 @@
+use super::RestQuery;
+use serde::{Deserialize, Serialize};
+
+pub struct StopMachine;
+
+impl RestQuery for StopMachine {
+    type RequestData = ();
+    type ResponseData = StopMachineResponse;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StopMachineResponse {
+    pub ok: bool,
+}

--- a/stamp/Dockerfile.full
+++ b/stamp/Dockerfile.full
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.4
-FROM ubuntu
+FROM ubuntu:20.04
 RUN apt-get update
 RUN yes | unminimize
-RUN apt-get install -y curl sudo htop tmux nano ncdu clang wget unzip zip git git-lfs build-essential jq less man-db ripgrep ninja-build cmake neofetch
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl sudo htop tmux nano ncdu clang wget unzip zip git git-lfs build-essential jq less man-db ripgrep ninja-build cmake neofetch
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 RUN curl -fsSL https://get.docker.com | sh

--- a/stamp/Dockerfile.minimal
+++ b/stamp/Dockerfile.minimal
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM ubuntu
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y curl sudo htop tmux nano ncdu wget unzip zip git less man-db
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh

--- a/stamp/Dockerfile.minimal-docker
+++ b/stamp/Dockerfile.minimal-docker
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM ubuntu
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y curl sudo htop tmux nano ncdu wget unzip zip git less man-db
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh


### PR DESCRIPTION
- Add cleanup command to destroy stopped machines
- Downgrade Ubuntu to 20.04 until Fly upgrades their host kernels
- Add dependency on `flyctl`