### PR TITLE
Switch to iptables-legacy for tailscale

### DIFF
--- a/stamp/Dockerfile.full
+++ b/stamp/Dockerfile.full
@@ -13,16 +13,8 @@ RUN passwd -d fade
 RUN touch /run/xtables.lock \
     && chmod a+r /run/xtables.lock
 
-RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
-    && cp /usr/sbin/iptables-legacy /usr/sbin/iptables \
-    && mv /usr/sbin/iptables-restore /usr/sbin/iptables-restore-broken \
-    && mv /usr/sbin/ip6tables-restore /usr/sbin/ip6tables-restore-broken \
-    && mv /usr/sbin/iptables-save /usr/sbin/iptables-save-broken \
-    && mv /usr/sbin/ip6tables-save /usr/sbin/ip6tables-save-broken \
-    && cp /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore \
-    && cp /usr/sbin/ip6tables-legacy-restore /usr/sbin/ip6tables-restore \
-    && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
-    && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 COPY --from=nebulatgs/fade-launch --link /target/launch /bin/launch
 ENTRYPOINT [ "/bin/bash", "-c", "dockerd & launch" ]

--- a/stamp/Dockerfile.minimal
+++ b/stamp/Dockerfile.minimal
@@ -11,16 +11,8 @@ RUN passwd -d fade
 RUN touch /run/xtables.lock \
     && chmod a+r /run/xtables.lock
 
-RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
-    && cp /usr/sbin/iptables-legacy /usr/sbin/iptables \
-    && mv /usr/sbin/iptables-restore /usr/sbin/iptables-restore-broken \
-    && mv /usr/sbin/ip6tables-restore /usr/sbin/ip6tables-restore-broken \
-    && mv /usr/sbin/iptables-save /usr/sbin/iptables-save-broken \
-    && mv /usr/sbin/ip6tables-save /usr/sbin/ip6tables-save-broken \
-    && cp /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore \
-    && cp /usr/sbin/ip6tables-legacy-restore /usr/sbin/ip6tables-restore \
-    && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
-    && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 COPY --from=nebulatgs/fade-launch --link /target/launch /bin/launch
 ENTRYPOINT [ "/bin/bash", "-c", "launch" ]

--- a/stamp/Dockerfile.minimal-docker
+++ b/stamp/Dockerfile.minimal-docker
@@ -11,16 +11,8 @@ RUN passwd -d fade
 RUN touch /run/xtables.lock \
     && chmod a+r /run/xtables.lock
 
-RUN mv /usr/sbin/iptables /usr/sbin/iptables-broken \
-    && cp /usr/sbin/iptables-legacy /usr/sbin/iptables \
-    && mv /usr/sbin/iptables-restore /usr/sbin/iptables-restore-broken \
-    && mv /usr/sbin/ip6tables-restore /usr/sbin/ip6tables-restore-broken \
-    && mv /usr/sbin/iptables-save /usr/sbin/iptables-save-broken \
-    && mv /usr/sbin/ip6tables-save /usr/sbin/ip6tables-save-broken \
-    && cp /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore \
-    && cp /usr/sbin/ip6tables-legacy-restore /usr/sbin/ip6tables-restore \
-    && cp /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save \
-    && cp /usr/sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 COPY --from=nebulatgs/fade-launch --link /target/launch /bin/launch
 ENTRYPOINT [ "/bin/bash", "-c", "dockerd & launch" ]


### PR DESCRIPTION
This should allow for `fade` machines to be used as exit nodes, since `tailscale` needs `iptables-legacy` and `ip6tables-legacy` for this to function